### PR TITLE
Trim SEVERITY_NUMBER_ from SeverityText

### DIFF
--- a/slogotlp.go
+++ b/slogotlp.go
@@ -366,7 +366,7 @@ func (h *Handler) convertRecord(r slog.Record) *logspb.LogRecord {
 		TimeUnixNano:         timeNow,
 		ObservedTimeUnixNano: timeNow,
 		SeverityNumber:       severityNumber,
-		SeverityText:         severityNumber.String(),
+		SeverityText:         strings.TrimPrefix(severityNumber.String(), "SEVERITY_NUMBER_"),
 		Body: &commonpb.AnyValue{
 			Value: &commonpb.AnyValue_StringValue{
 				StringValue: r.Message,

--- a/slogotlp_test.go
+++ b/slogotlp_test.go
@@ -110,6 +110,7 @@ func TestTypes(t *testing.T) {
 			},
 			validator: func(is *is.I, lr *logspb.LogRecord) {
 				is.Equal(42.0, getAttribute(is, lr, "float").GetDoubleValue())
+				is.Equal(lr.SeverityText, "INFO")
 			},
 		},
 		"error": {


### PR DESCRIPTION
I'm seeing `{"level":"SEVERITY_NUMBER_INFO","message":"my log message"}` sent to the collector and it cannot parse the level

Thanks