### PR TITLE
Fix slog group handling and add group tests

### DIFF
--- a/slogotlp.go
+++ b/slogotlp.go
@@ -300,7 +300,9 @@ func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
 	return level >= h.level
 }
 
-// WithGroup is a no-op, as we do not support groups yet.
+// WithGroup returns a new Handler that nests subsequent attributes under the
+// given group name. Nested groups produce nested OTLP KvlistValue attributes.
+// Empty groups (no attributes) are omitted from the output.
 func (h *Handler) WithGroup(name string) slog.Handler {
 	h2 := *h
 
@@ -387,8 +389,9 @@ func (h *Handler) convertRecord(r slog.Record) *logspb.LogRecord {
 				record.Attributes = append(record.Attributes, g.KeyValue())
 			}
 		}
-	} else if n > 0 {
-		buf := newKVBuffer(n)
+	} else {
+		buf := newKVBuffer(len(h.attrs) + n)
+		buf.AddAttrs(h.attrs)
 		r.Attrs(buf.AddAttr)
 		record.Attributes = append(record.Attributes, buf.data...)
 	}
@@ -653,7 +656,7 @@ func (g *group) KeyValue(kvs ...*commonpb.KeyValue) *commonpb.KeyValue {
 		Value: &commonpb.AnyValue{
 			Value: &commonpb.AnyValue_KvlistValue{
 				KvlistValue: &commonpb.KeyValueList{
-					Values: g.attrs.data,
+					Values: g.attrs.KeyValues(kvs...),
 				},
 			},
 		},
@@ -661,20 +664,19 @@ func (g *group) KeyValue(kvs ...*commonpb.KeyValue) *commonpb.KeyValue {
 
 	g = g.next
 	for g != nil {
-		// A Handler should not output groups if there are no attributes.
+		values := []*commonpb.KeyValue{out}
 		if g.attrs.Len() > 0 {
-			out = &commonpb.KeyValue{
-				Key: g.name,
-				Value: &commonpb.AnyValue{
-					Value: &commonpb.AnyValue_KvlistValue{
-						KvlistValue: &commonpb.KeyValueList{
-							Values: []*commonpb.KeyValue{
-								out,
-							},
-						},
+			values = append(g.attrs.data, out)
+		}
+		out = &commonpb.KeyValue{
+			Key: g.name,
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_KvlistValue{
+					KvlistValue: &commonpb.KeyValueList{
+						Values: values,
 					},
 				},
-			}
+			},
 		}
 		g = g.next
 	}

--- a/slogotlp_test.go
+++ b/slogotlp_test.go
@@ -83,6 +83,183 @@ func (t *testCollector) Export(_ context.Context, request *collectorLogs.ExportL
 	return &collectorLogs.ExportLogsServiceResponse{}, nil
 }
 
+func newTestHandler(t *testing.T) (*slogotlp.Handler, *testCollector) {
+	t.Helper()
+	is := is.New(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	is.NoErr(err)
+
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	collector := &testCollector{}
+
+	g := grpc.NewServer()
+	collectorLogs.RegisterLogsServiceServer(g, collector)
+
+	go func() {
+		_ = g.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		g.Stop()
+	})
+
+	handler, err := slogotlp.NewHandler(
+		context.Background(),
+		slogotlp.WithEndpoint("http://"+listener.Addr().String()),
+		slogotlp.WithDialOptions(grpc.WithBlock()),
+	)
+	is.NoErr(err)
+
+	t.Cleanup(func() {
+		_ = handler.Shutdown(context.Background())
+	})
+
+	return handler, collector
+}
+
+func findAttr(attrs []*commonpb.KeyValue, key string) *commonpb.AnyValue {
+	for _, a := range attrs {
+		if a.Key == key {
+			return a.Value
+		}
+	}
+	return nil
+}
+
+func kvList(av *commonpb.AnyValue) []*commonpb.KeyValue {
+	if av == nil {
+		return nil
+	}
+	return av.GetKvlistValue().GetValues()
+}
+
+func TestGroups(t *testing.T) {
+	tests := map[string]struct {
+		log      func(*slog.Logger)
+		validate func(*is.I, *logspb.LogRecord)
+	}{
+		"WithGroup single": {
+			log: func(l *slog.Logger) {
+				l.WithGroup("g").Info("m", "k", "v")
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				is.Equal(1, len(lr.Attributes))
+				g := findAttr(lr.Attributes, "g")
+				is.True(g != nil)
+				inner := kvList(g)
+				is.Equal(1, len(inner))
+				is.Equal("k", inner[0].Key)
+				is.Equal("v", inner[0].Value.GetStringValue())
+			},
+		},
+		"WithGroup nested": {
+			log: func(l *slog.Logger) {
+				l.WithGroup("a").WithGroup("b").Info("m", "k", int64(1))
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				a := findAttr(lr.Attributes, "a")
+				is.True(a != nil)
+				aKvs := kvList(a)
+				is.Equal(1, len(aKvs))
+				is.Equal("b", aKvs[0].Key)
+				bKvs := kvList(aKvs[0].Value)
+				is.Equal(1, len(bKvs))
+				is.Equal("k", bKvs[0].Key)
+				is.Equal(int64(1), bKvs[0].Value.GetIntValue())
+			},
+		},
+		"WithAttrs inside group": {
+			log: func(l *slog.Logger) {
+				l.WithGroup("g").With("k1", "v1").Info("m", "k2", "v2")
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				g := findAttr(lr.Attributes, "g")
+				is.True(g != nil)
+				inner := kvList(g)
+				is.Equal(2, len(inner))
+				is.Equal("v1", findAttr(inner, "k1").GetStringValue())
+				is.Equal("v2", findAttr(inner, "k2").GetStringValue())
+			},
+		},
+		"inline slog.Group": {
+			log: func(l *slog.Logger) {
+				l.Info("m", slog.Group("g", "k", "v"))
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				g := findAttr(lr.Attributes, "g")
+				is.True(g != nil)
+				inner := kvList(g)
+				is.Equal(1, len(inner))
+				is.Equal("k", inner[0].Key)
+				is.Equal("v", inner[0].Value.GetStringValue())
+			},
+		},
+		"inline group inside WithGroup": {
+			log: func(l *slog.Logger) {
+				l.WithGroup("outer").Info("m", slog.Group("inner", "k", "v"))
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				outer := findAttr(lr.Attributes, "outer")
+				is.True(outer != nil)
+				outerKvs := kvList(outer)
+				is.Equal(1, len(outerKvs))
+				is.Equal("inner", outerKvs[0].Key)
+				innerKvs := kvList(outerKvs[0].Value)
+				is.Equal(1, len(innerKvs))
+				is.Equal("k", innerKvs[0].Key)
+				is.Equal("v", innerKvs[0].Value.GetStringValue())
+			},
+		},
+		"empty-key group inlined": {
+			log: func(l *slog.Logger) {
+				l.Info("m", slog.Group("", "k", "v"))
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				is.Equal(1, len(lr.Attributes))
+				is.Equal("k", lr.Attributes[0].Key)
+				is.Equal("v", lr.Attributes[0].Value.GetStringValue())
+			},
+		},
+		"empty group skipped": {
+			log: func(l *slog.Logger) {
+				l.WithGroup("g").Info("m")
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				is.Equal(0, len(lr.Attributes))
+			},
+		},
+		"WithAttrs no group": {
+			log: func(l *slog.Logger) {
+				l.With("top", "x").Info("m", "k", "v")
+			},
+			validate: func(is *is.I, lr *logspb.LogRecord) {
+				is.Equal(2, len(lr.Attributes))
+				is.Equal("x", findAttr(lr.Attributes, "top").GetStringValue())
+				is.Equal("v", findAttr(lr.Attributes, "k").GetStringValue())
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+			handler, collector := newTestHandler(t)
+
+			logger := slog.New(handler)
+			test.log(logger)
+
+			is.NoErr(handler.Shutdown(context.Background()))
+			is.Equal(1, len(collector.logRecords))
+			is.Equal("m", collector.logRecords[0].Body.GetStringValue())
+			test.validate(is, collector.logRecords[0])
+		})
+	}
+}
+
 func TestTypes(t *testing.T) {
 	getAttribute := func(is *is.I, lr *logspb.LogRecord, key string) *commonpb.AnyValue {
 		is.Helper()


### PR DESCRIPTION
## Summary
- Fix `WithGroup` so nested chains always nest (intermediate empty groups no longer collapse) and so `group.KeyValue` honors the passed kvs without nil-deref when the group has no own attrs.
- Fix `convertRecord` to include `h.attrs` when no group is active — previously `WithAttrs` without `WithGroup` silently dropped attributes.
- Replace stale `WithGroup` doc comment ("no-op") with accurate description.
- Add `TestGroups` covering single/nested `WithGroup`, `WithAttrs` inside groups, inline `slog.Group`, empty-key inlining, and empty-group skipping. Extract `newTestHandler` helper to deduplicate test setup.

## Test plan
- [x] `go test ./...` passes
- [ ] Verify OTLP collector receives expected `KvlistValue` nesting for grouped attributes in a real export

🤖 Generated with [Claude Code](https://claude.com/claude-code)