### PR TITLE
Add golangci-lint config and fix surfaced issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,73 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - copyloopvar
+    - errorlint
+    - gocritic
+    - gosec
+    - misspell
+    - nilerr
+    - noctx
+    - prealloc
+    - revive
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+  settings:
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+    gosec:
+      excludes:
+        - G115
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: var-declaration
+        - name: var-naming
+  exclusions:
+    presets:
+      - common-false-positives
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gosec
+          - noctx
+          - unparam
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/bakins/slogotlp
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/slogotlp.go
+++ b/slogotlp.go
@@ -683,9 +683,16 @@ func (g *group) KeyValue(kvs ...*commonpb.KeyValue) *commonpb.KeyValue {
 	return out
 }
 
+// KeyValues returns a fresh slice combining b.data and kvs. It always
+// allocates a new backing array so callers can store the result without risk
+// of later appends into b.data overwriting earlier results (which would
+// corrupt buffered log records before export).
 func (b *kvBuffer) KeyValues(kvs ...*commonpb.KeyValue) []*commonpb.KeyValue {
 	if b == nil {
-		return kvs
+		return slices.Clone(kvs)
 	}
-	return append(b.data, kvs...)
+	out := make([]*commonpb.KeyValue, 0, len(b.data)+len(kvs))
+	out = append(out, b.data...)
+	out = append(out, kvs...)
+	return out
 }

--- a/slogotlp.go
+++ b/slogotlp.go
@@ -128,7 +128,7 @@ type grpcExporter struct {
 	conn   *grpc.ClientConn
 }
 
-func newGrpcExporter(ctx context.Context, opts handlerOptions) (*grpcExporter, error) {
+func newGrpcExporter(_ context.Context, opts handlerOptions) (*grpcExporter, error) {
 	if opts.endpoint == "" {
 		exporterTarget := os.Getenv(otlpLogsEndpointEnv)
 		if exporterTarget == "" {
@@ -143,7 +143,7 @@ func newGrpcExporter(ctx context.Context, opts handlerOptions) (*grpcExporter, e
 
 	u, err := url.Parse(opts.endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("unabel to parse endpoint %v", err)
+		return nil, fmt.Errorf("unable to parse endpoint %w", err)
 	}
 
 	if opts.insecure == nil {
@@ -291,7 +291,7 @@ type Handler struct {
 var _ slog.Handler = &Handler{}
 
 // Shutdown shutsdown the handler. This should be called before the process exits
-// to flush buffers and close conenctions.
+// to flush buffers and close connections.
 func (h *Handler) Shutdown(ctx context.Context) error {
 	return h.exporter.Shutdown(ctx)
 }
@@ -666,7 +666,7 @@ func (g *group) KeyValue(kvs ...*commonpb.KeyValue) *commonpb.KeyValue {
 	for g != nil {
 		values := []*commonpb.KeyValue{out}
 		if g.attrs.Len() > 0 {
-			values = append(g.attrs.data, out)
+			values = append(slices.Clone(g.attrs.data), out)
 		}
 		out = &commonpb.KeyValue{
 			Key: g.name,

--- a/slogotlp_test.go
+++ b/slogotlp_test.go
@@ -168,7 +168,7 @@ func TestInsecureEnv(t *testing.T) {
 			handler, err := slogotlp.NewHandler(
 				t.Context(),
 				slogotlp.WithEndpoint("//"+listener.Addr().String()),
-					)
+			)
 			is.NoErr(err)
 			t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
 

--- a/slogotlp_test.go
+++ b/slogotlp_test.go
@@ -201,6 +201,96 @@ func TestInsecureEnvInvalid(t *testing.T) {
 	is.True(err != nil)
 }
 
+// TestGroupSiblingIsolation guards against backing-array aliasing in
+// kvBuffer.KeyValues / group.KeyValue. A single logger built with WithGroup
+// + With(...) is reused for multiple sibling log calls. Each call must produce
+// a record with its own per-call attribute, and earlier records must not be
+// mutated by later ones (records are buffered before export, so any aliasing
+// of the group's attrs slice would corrupt earlier records when later calls
+// append into the same backing array).
+func TestGroupSiblingIsolation(t *testing.T) {
+	is := is.New(t)
+	handler, collector := newTestHandler(t)
+
+	lg := slog.New(handler).WithGroup("g").With("static", "fixed")
+	for i := range 5 {
+		lg.Info("m", "i", int64(i))
+	}
+
+	is.NoErr(handler.Shutdown(context.Background()))
+	is.Equal(5, len(collector.logRecords))
+
+	for idx, rec := range collector.logRecords {
+		g := findAttr(rec.Attributes, "g")
+		is.True(g != nil)
+		inner := kvList(g)
+		is.Equal(2, len(inner))
+		is.Equal("fixed", findAttr(inner, "static").GetStringValue())
+		is.Equal(int64(idx), findAttr(inner, "i").GetIntValue())
+	}
+}
+
+// TestNestedGroupSiblingIsolation does the same as above with a nested group
+// chain, exercising the outer-group wrapping path in group.KeyValue.
+func TestNestedGroupSiblingIsolation(t *testing.T) {
+	is := is.New(t)
+	handler, collector := newTestHandler(t)
+
+	lg := slog.New(handler).WithGroup("outer").With("o", "fixed").WithGroup("inner").With("in", "static")
+	for i := range 4 {
+		lg.Info("m", "i", int64(i))
+	}
+
+	is.NoErr(handler.Shutdown(context.Background()))
+	is.Equal(4, len(collector.logRecords))
+
+	for idx, rec := range collector.logRecords {
+		outer := findAttr(rec.Attributes, "outer")
+		is.True(outer != nil)
+		oKvs := kvList(outer)
+		is.Equal("fixed", findAttr(oKvs, "o").GetStringValue())
+		inner := findAttr(oKvs, "inner")
+		is.True(inner != nil)
+		iKvs := kvList(inner)
+		is.Equal("static", findAttr(iKvs, "in").GetStringValue())
+		is.Equal(int64(idx), findAttr(iKvs, "i").GetIntValue())
+	}
+}
+
+// TestSiblingHandlersIsolated guards against shared state when WithAttrs is
+// called twice on the same parent group handler to produce two siblings.
+func TestSiblingHandlersIsolated(t *testing.T) {
+	is := is.New(t)
+	handler, collector := newTestHandler(t)
+
+	parent := slog.New(handler).WithGroup("g")
+	a := parent.With("who", "a")
+	b := parent.With("who", "b")
+
+	a.Info("m", "k", "av")
+	b.Info("m", "k", "bv")
+
+	is.NoErr(handler.Shutdown(context.Background()))
+	is.Equal(2, len(collector.logRecords))
+
+	for _, rec := range collector.logRecords {
+		g := findAttr(rec.Attributes, "g")
+		is.True(g != nil)
+		inner := kvList(g)
+		is.Equal(2, len(inner))
+		who := findAttr(inner, "who").GetStringValue()
+		k := findAttr(inner, "k").GetStringValue()
+		switch who {
+		case "a":
+			is.Equal("av", k)
+		case "b":
+			is.Equal("bv", k)
+		default:
+			is.Fail()
+		}
+	}
+}
+
 func TestGroups(t *testing.T) {
 	tests := map[string]struct {
 		log      func(*slog.Logger)


### PR DESCRIPTION
## Summary
- Add `.golangci.yml` (v2 schema) — curated linter set on top of the standard defaults: `bodyclose`, `copyloopvar`, `errorlint`, `gocritic`, `gosec`, `misspell`, `nilerr`, `noctx`, `prealloc`, `revive`, `unconvert`, `unparam`, `usestdlibvars`. Formatters: `gofumpt`, `goimports`. Tests get a relaxed exclusion list (errcheck, gosec, noctx, unparam).
- Fix all issues the new config surfaced:
  - `errorlint`: `%v` → `%w` in `url.Parse` error wrap; also fix `unabel` typo.
  - `misspell`: `conenctions` → `connections`.
  - `unparam`: unused `ctx` in `newGrpcExporter` renamed to `_` (kept the parameter to preserve the internal call site).
  - `gocritic` `appendAssign`: clone `g.attrs.data` before appending in `group.KeyValue` to avoid aliasing the backing array.
  - `gofumpt`: reformat `slogotlp_test.go`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
